### PR TITLE
Adds deck navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ use a heredoc for a better inline UX. It is typical to make many calls to
 `slide` from within the same file to simulate a slide "deck", displaying one
 after the other.
 
+The exit code from `slide` represents the character which was entered on the
+keyboard at exit time. Specifically:
+
+    * `0`: Enter, or an unrecognized character.
+    * `255`: Backspace
+    * `1..254`: Typed number followed by the Enter key.
+
+Typically the return code is ignored by the caller, but it can be used by other
+programs to provide navigation if desired (see the `deck` command, for example).
+
 ```
 deck <directory of *.slide files>
 ```
@@ -79,6 +89,7 @@ note when using this command:
   directory will cause undefined behavior.
 * Slides are loaded in lexical order. To order slides, rename them so the sort
   in the order you desire.
+* Slide navigation supports 254 slides at the max.
 
 Use Cases
 ---------

--- a/slide.sh
+++ b/slide.sh
@@ -33,9 +33,9 @@ function slide() {
         $TPUT cup $ROWS $COLS && let LINENUM++
         [ ${#BARE} -gt $COLS ] && let LINENUM++
     done
-    for ((GOTO=0;;)); do
+    for ((GOTO=0;;${GOTO:=0})); do
         $TPUT cup $ROWS 0 && printf "%${MSGPOS}s\033[0m%s" " " $MESSAGE
-        [ $GOTO -gt 0 ] && $TPUT cup $ROWS 0 && printf "\033[0mJump: ${GOTO}"
+        [ ${GOTO} -gt 0 ] && $TPUT cup $ROWS 0 && printf "\033[0mJump: ${GOTO}"
         read -s -n 1 CHAR < /dev/tty
         case $CHAR in
             $'\033')     GOTO=0                                          ;;
@@ -50,16 +50,11 @@ function deck() {
     local -r FILES=($1/*.slide)
     local -ri TOTAL=${#FILES[@]}
     [ $TOTAL -gt 254 ] && TOTAL=254
-    for ((i=1;;)); do
-        i=$((i>TOTAL?TOTAL:(i<1?1:i)))
+    for ((i=1;;i=$((i>TOTAL?TOTAL:(i<1?1:i))))); do
         FILE=${FILES[$((i-1))]}
         MSG="Slide ${i}/${TOTAL} | ↲ Next | ← Back | 1..${TOTAL} Jump | ^c Quit"
         CONTENT=$(<$FILE)
         eval "echo \"${CONTENT//\"/\\\"}\"" | slide "$MSG"
-        case $? in
-            255) let i-- ;;
-            0)   let i++ ;;
-            *)   i=$?    ;;
-        esac
+        i=$(($?==255?(i-1):($?==0?i+1:$?)))
     done
 }

--- a/slide.sh
+++ b/slide.sh
@@ -51,16 +51,15 @@ function deck() {
     local -ri TOTAL=${#FILES[@]}
     [ $TOTAL -gt 254 ] && TOTAL=254
     for ((i=1;;)); do
-        [ $i -lt 1 ] && i=1
-        [ $i -gt $TOTAL ] && i=$TOTAL
+        i=$((i>TOTAL?TOTAL:(i<1?1:i)))
         FILE=${FILES[$((i-1))]}
-        MSG="Slide ${i}/${TOTAL} | ↲ Next | ← Back | 0..${TOTAL} Jump | ^c Quit"
+        MSG="Slide ${i}/${TOTAL} | ↲ Next | ← Back | 1..${TOTAL} Jump | ^c Quit"
         CONTENT=$(<$FILE)
         eval "echo \"${CONTENT//\"/\\\"}\"" | slide "$MSG"
         case $? in
-            255) i=$((i-1)) ;;
-            0)   i=$((i+1)) ;;
-            *)   i=$?       ;;
+            255) let i-- ;;
+            0)   let i++ ;;
+            *)   i=$?    ;;
         esac
     done
 }

--- a/slide.sh
+++ b/slide.sh
@@ -33,14 +33,15 @@ function slide() {
         $TPUT cup $ROWS $COLS && let LINENUM++
         [ ${#BARE} -gt $COLS ] && let LINENUM++
     done
-    $TPUT cup $ROWS $MSGPOS && printf "\033[0m${MESSAGE}"
     for ((GOTO=0;;)); do
-        [ $GOTO -gt 254 ] && GOTO=254
+        $TPUT cup $ROWS 0 && printf "%${MSGPOS}s\033[0m%s" " " $MESSAGE
+        [ $GOTO -gt 0 ] && $TPUT cup $ROWS 0 && printf "\033[0mJump: ${GOTO}"
         read -s -n 1 CHAR < /dev/tty
         case $CHAR in
-            $'\177')     return 255   ;;
-            [[:digit:]]) GOTO+=$CHAR  ;;
-            *)           return $GOTO ;;
+            $'\033')     GOTO=0                                          ;;
+            $'\177')     [ $GOTO -eq 0 ] && return 255 || GOTO=${GOTO%?} ;;
+            [[:digit:]]) [ $GOTO -eq 0 ] && GOTO=$CHAR || GOTO+=$CHAR    ;;
+            *)           [ $GOTO -gt 254 ] && return 254 || return $GOTO ;;
         esac
     done
 }

--- a/slide.sh
+++ b/slide.sh
@@ -2,7 +2,7 @@
 function slide() {
     local -r TPUT=$(type -p tput)
     [ -x "$TPUT" ] || exit 1
-    local -r IFS='' MESSAGE=${1:-<Enter> Next slide | <ctrl+c> Quit}
+    local -r IFS='' MESSAGE=${1:-↲ Next | ^c Quit}
     local -r COLORS=(red=31 green=32 yellow=33 blue=34 purple=35 cyan=36 end=)
     local -ri COLS=$($TPUT cols) ROWS=$($TPUT lines)
     local -i CENTER=0 LINENUM=0 CTRPOS=0 MSGPOS=0 HASCOLOR=1
@@ -54,14 +54,13 @@ function deck() {
         [ $i -lt 1 ] && i=1
         [ $i -gt $TOTAL ] && i=$TOTAL
         FILE=${FILES[$((i-1))]}
-        MSG="Slide ${i}/${TOTAL} | <Enter> Next | <Backspace> Previous | <0..${TOTAL}> Jump | <ctrl+c> Quit"
+        MSG="Slide ${i}/${TOTAL} | ↲ Next | ← Back | 0..${TOTAL} Jump | ^c Quit"
         CONTENT=$(<$FILE)
         eval "echo \"${CONTENT//\"/\\\"}\"" | slide "$MSG"
-        CMD=$?
-        case $CMD in
+        case $? in
             255) i=$((i-1)) ;;
             0)   i=$((i+1)) ;;
-            *)   i=$CMD     ;;
+            *)   i=$?       ;;
         esac
     done
 }


### PR DESCRIPTION
This implements basic navigation in the `deck` command. This covers the same ground as #3, with the following perks:
- Preserves the original `slide` command functionality to avoid breaking existing slide decks.
- Single-press forward/back controls
- Improved slide selection when entering digits
